### PR TITLE
Update instructions

### DIFF
--- a/StRoot/StPicoD0AnaMaker/README.md
+++ b/StRoot/StPicoD0AnaMaker/README.md
@@ -20,19 +20,11 @@ cd myAnalysis
 # Replace address below with your own fork if you have one
 git clone git@github.com:rnc-lbl/auau200GeVRun14.git
 
-# If you want to use D0 trees produced for the pico production I (tagged physics as ooposed to physics2 for production II).  
-cd auau200GeVRun14
-git checkout v1.0
-cd ..
-
 # Now you need to get StPicoDstMaker
 # If compiling at PDSF you need to get a klog token as below.
 # - You don't need this step at RCF - 
 # You will need to enter your RCF password.
 klog -principal YOURRCFUSERNAME
-
-# For pico production I 
-cvs co -r Run14_AuAu200_physics offline/users/dongx/pico/source/StPicoDstMaker
 
 # For pico production II
 cvs co -r Run14_AuAu200_physics2 offline/users/dongx/pico/source/StPicoDstMaker

--- a/StRoot/StPicoD0AnaMaker/README.md
+++ b/StRoot/StPicoD0AnaMaker/README.md
@@ -18,7 +18,7 @@ cd myAnalysis
 
 # Clone LBNL PicoHFLib
 # Replace address below with your own fork if you have one
-git clone git@github.com:rnc-lbl/auau200GeVRun14.git
+git clone https://github.com/rnc-lbl/auau200GeVRun14.git
 
 # Now you need to get StPicoDstMaker
 # If compiling at PDSF you need to get a klog token as below.


### PR DESCRIPTION
- Remove instructions for pico production I. 
- Use https instead of ssh for repo address. 