### PR TITLE
Do not use automatic ROOT I/O for StMakers

### DIFF
--- a/StRoot/StPicoD0AnaMaker/StPicoD0AnaMaker.h
+++ b/StRoot/StPicoD0AnaMaker/StPicoD0AnaMaker.h
@@ -62,7 +62,7 @@ class StPicoD0AnaMaker : public StMaker
     // add your member variables here. 
     // Remember that ntuples size can be really big, use histograms where appropriate
 
-    ClassDef(StPicoD0AnaMaker, 1)
+    ClassDef(StPicoD0AnaMaker, 0)
 };
 
 inline int StPicoD0AnaMaker::getEntries() const 

--- a/StRoot/StPicoD0EventMaker/StPicoD0EventMaker.h
+++ b/StRoot/StPicoD0EventMaker/StPicoD0EventMaker.h
@@ -53,7 +53,7 @@ class StPicoD0EventMaker : public StMaker
     TTree* mTree;
     StPicoD0Event* mPicoD0Event;
 
-    ClassDef(StPicoD0EventMaker, 1)
+    ClassDef(StPicoD0EventMaker, 0)
 };
 
 #endif

--- a/StRoot/StPicoHFMaker/StPicoHFMaker.h
+++ b/StRoot/StPicoHFMaker/StPicoHFMaker.h
@@ -160,7 +160,7 @@ class StPicoHFMaker : public StMaker
 
     TFile*          mOutputFileTree;     // ptr to file saving the HFtree
     TFile*          mOutputFileList;     // ptr to file saving the list of histograms
-    ClassDef(StPicoHFMaker, 1)
+    ClassDef(StPicoHFMaker, 0)
 };
 
 inline void StPicoHFMaker::setHFBaseCuts(StHFCuts* cuts)   { mHFCuts = cuts; }

--- a/StRoot/StPicoHFMyAnaMaker/StPicoHFMyAnaMaker.h
+++ b/StRoot/StPicoHFMyAnaMaker/StPicoHFMyAnaMaker.h
@@ -102,7 +102,7 @@ class StPicoHFMyAnaMaker : public StPicoHFMaker
 
   // -- ADD USER MEMBERS HERE -------------------
 
-  ClassDef(StPicoHFMyAnaMaker, 1)
+  ClassDef(StPicoHFMyAnaMaker, 0)
 };
 
 #endif

--- a/StRoot/StPicoNpeAnaMaker/StPicoNpeAnaMaker.h
+++ b/StRoot/StPicoNpeAnaMaker/StPicoNpeAnaMaker.h
@@ -67,7 +67,7 @@ class StPicoNpeAnaMaker : public StMaker
     
     
     
-    ClassDef(StPicoNpeAnaMaker, 2)
+    ClassDef(StPicoNpeAnaMaker, 0)
 };
 
 inline int StPicoNpeAnaMaker::getEntries() const 

--- a/StRoot/StPicoNpeEventMaker/StPicoNpeEventMaker.h
+++ b/StRoot/StPicoNpeEventMaker/StPicoNpeEventMaker.h
@@ -49,7 +49,7 @@ class StPicoNpeEventMaker : public StMaker
     TTree* mTree;
     StPicoNpeEvent* mPicoNpeEvent;
 
-    ClassDef(StPicoNpeEventMaker, 2)
+    ClassDef(StPicoNpeEventMaker, 0)
 };
 
 #endif


### PR DESCRIPTION
I/O is not necessary since StMakers are not (and should not be) persistent.
Avoiding unnecessary code will also help to slightly speed up code compilation.